### PR TITLE
refactor: simplify schemas, manifest builder, and registry error hand…

### DIFF
--- a/.changeset/yellow-pens-retire.md
+++ b/.changeset/yellow-pens-retire.md
@@ -1,0 +1,5 @@
+---
+"docker-tar-pusher": patch
+---
+
+Fix layer accumulation bug when pushing images with multiple RepoTags. Refactor ManifestBuilder into a pure function, consolidate option schemas with defaults via v.parse, and use isAxiosError consistently in registry error handling.

--- a/.env.ci
+++ b/.env.ci
@@ -1,1 +1,0 @@
-REGISTRY_URL=http://localhost:15000

--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,1 @@
-REGISTRY_URL=http://localhost:5001
+REGISTRY_URL=http://localhost:15000

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -52,8 +52,6 @@ jobs:
         run: pnpm build
 
       - name: Run tests
-        env:
-          REGISTRY_URL: 'http://localhost:5000'
         run: pnpm test --coverage
 
       - name: Report Coverage

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,0 @@
-build/
-coverage/
-pnpm-lock.yaml
-.prettierrc
-.eslintrc.js
-CHANGELOG.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,0 @@
-{
-  "semi": true,
-  "trailingComma": "none",
-  "singleQuote": true,
-  "printWidth": 120
-}

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,6 @@
+services:
+  registry:
+    image: registry:2
+    ports:
+      - "5001:5000"
+    restart: always

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,5 +2,5 @@ services:
   registry:
     image: registry:2
     ports:
-      - "5001:5000"
+      - "15000:5000"
     restart: always

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "docker image",
     "docker tar"
   ],
-  "author": "Károly Pákozdi <karoly.pakozdi.150@gmail.com>",
+  "author": "Károly Pákozdi <karoly@pkzd.hu>",
   "license": "MIT",
   "devDependencies": {
     "@biomejs/biome": "2.2.6",
@@ -48,5 +48,5 @@
     "tar": "^6.1.11",
     "valibot": "^1.1.0"
   },
-  "packageManager": "pnpm@10.18.3+sha512.bbd16e6d7286fd7e01f6b3c0b3c932cda2965c06a908328f74663f10a9aea51f1129eea615134bf992831b009eabe167ecb7008b597f40ff9bc75946aadfb08d"
+  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264"
 }

--- a/src/dtp/ManifestBuilder.ts
+++ b/src/dtp/ManifestBuilder.ts
@@ -1,44 +1,18 @@
-import ManifestError from "../errors/ManifestError";
-import type { ChunkMetaData, Config, Layer, RegistryManifest } from "../types";
+import type { ChunkMetaData } from "../types";
 import { ContentTypes } from "../types";
 
-export default class ManifestBuilder {
-  private layers?: Layer[];
-  private config?: Config;
-
-  public buildManifest(): RegistryManifest {
-    if (!this.config || !this.layers) {
-      throw new ManifestError(
-        "Cannot build manifest: config or layers are not set",
-        {
-          operation: "build",
-        },
-      );
-    }
-    return {
-      config: this.config,
-      layers: this.layers,
-      schemaVersion: 2,
-      mediaType: ContentTypes.APPLICATION_MANIFEST,
-    };
-  }
-
-  public addLayer({ digest, size }: ChunkMetaData): void {
-    if (!this.layers) {
-      this.layers = [];
-    }
-    this.layers.push({
-      digest,
-      size,
-      mediaType: ContentTypes.APPLICATION_LAYER,
-    });
-  }
-
-  public setConfig({ digest, size }: ChunkMetaData): void {
-    this.config = {
-      digest,
-      size,
-      mediaType: ContentTypes.APPLICATION_CONFIG,
-    };
-  }
-}
+export const buildManifest = (
+  layerChunks: ChunkMetaData[],
+  config: ChunkMetaData,
+) => ({
+  config: {
+    ...config,
+    mediaType: ContentTypes.APPLICATION_CONFIG,
+  },
+  layers: layerChunks.map((layerChunk) => ({
+    ...layerChunk,
+    mediaType: ContentTypes.APPLICATION_LAYER,
+  })),
+  schemaVersion: 2,
+  mediaType: ContentTypes.APPLICATION_MANIFEST,
+});

--- a/src/errors/DockerTarPusherError.ts
+++ b/src/errors/DockerTarPusherError.ts
@@ -1,8 +1,0 @@
-export default class DockerTarPusherError extends Error {
-  constructor(
-    message: string,
-    public readonly context?: unknown,
-  ) {
-    super(message);
-  }
-}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,6 @@
 import { execSync } from "node:child_process";
-import { beforeAll, describe, expect, test } from "vitest";
+import { rmSync } from "node:fs";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { DockerTarPusher } from "./index";
 
 const images = ["busybox", "alpine", "nginx"];
@@ -9,6 +10,12 @@ beforeAll(() => {
   for (const image of images) {
     execSync(`docker pull ${image}:latest`);
     execSync(`docker save ${image}:latest | gzip > /tmp/${image}.tar.gz`);
+  }
+}, 120_000);
+
+afterAll(() => {
+  for (const image of images) {
+    rmSync(`/tmp/${image}.tar.gz`, { force: true });
   }
 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { DockerTarPusher } from "./index";
 
 const images = ["busybox", "alpine", "nginx"];
-const registryUrl = process.env.REGISTRY_URL || "http://localhost:5000";
+const registryUrl = process.env.REGISTRY_URL || "http://localhost:15000";
 
 beforeAll(() => {
   for (const image of images) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,8 +13,6 @@ export const ManifestSchema = v.pipe(
   })),
 );
 
-export type Manifest = v.InferOutput<typeof ManifestSchema>;
-
 export const AuthSchema = v.object({
   username: v.string(),
   password: v.string(),
@@ -27,15 +25,22 @@ export const ImageSchema = v.object({
 
 export const ProgressCallbackSchema = v.function();
 
-export const DockerTarPusherOptionsSchema = v.object({
-  registryUrl: v.string(),
-  tarball: v.string(),
-  chunkSize: v.fallback(v.number(), 10 * 1024 * 1024),
-  sslVerify: v.fallback(v.boolean(), true),
-  auth: v.optional(AuthSchema),
-  image: v.optional(ImageSchema),
-  onProgress: v.optional(ProgressCallbackSchema),
-});
+export const DockerTarPusherOptionsSchema = v.pipe(
+  v.object({
+    registryUrl: v.string(),
+    tarball: v.string(),
+    chunkSize: v.optional(v.number()),
+    sslVerify: v.optional(v.boolean()),
+    auth: v.optional(AuthSchema),
+    image: v.optional(ImageSchema),
+    onProgress: v.optional(ProgressCallbackSchema),
+  }),
+  v.transform((input) => ({
+    ...input,
+    chunkSize: input.chunkSize ?? 10 * 1024 * 1024,
+    sslVerify: input.sslVerify ?? true,
+  })),
+);
 
 export type Layer = {
   size: number;
@@ -79,8 +84,6 @@ export enum ContentTypes {
 }
 
 export type Auth = v.InferInput<typeof AuthSchema>;
-export type Image = v.InferInput<typeof ImageSchema>;
-export type ProgressCallback = v.InferInput<typeof ProgressCallbackSchema>;
 export type ApplicationConfiguration = v.InferOutput<
   typeof DockerTarPusherOptionsSchema
 >;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,19 @@
 import * as v from "valibot";
 
-export const ManifestSchema = v.object({
-  Config: v.string(),
-  RepoTags: v.array(v.string()),
-  Layers: v.array(v.string()),
-});
+export const ManifestSchema = v.pipe(
+  v.object({
+    Config: v.string(),
+    RepoTags: v.array(v.string()),
+    Layers: v.array(v.string()),
+  }),
+  v.transform(({ Config, RepoTags, Layers }) => ({
+    config: Config,
+    repoTags: RepoTags,
+    layers: Layers,
+  })),
+);
 
-export type Manifest = v.InferInput<typeof ManifestSchema>;
+export type Manifest = v.InferOutput<typeof ManifestSchema>;
 
 export const AuthSchema = v.object({
   username: v.string(),
@@ -20,23 +27,11 @@ export const ImageSchema = v.object({
 
 export const ProgressCallbackSchema = v.function();
 
-// Base schema with all optional fields for user input
 export const DockerTarPusherOptionsSchema = v.object({
   registryUrl: v.string(),
   tarball: v.string(),
-  chunkSize: v.optional(v.number()),
-  sslVerify: v.optional(v.boolean()),
-  auth: v.optional(AuthSchema),
-  image: v.optional(ImageSchema),
-  onProgress: v.optional(ProgressCallbackSchema),
-});
-
-// Derived schema for internal application configuration with required fields
-export const ApplicationConfigurationSchema = v.object({
-  registryUrl: v.string(),
-  tarball: v.string(),
-  chunkSize: v.number(),
-  sslVerify: v.boolean(),
+  chunkSize: v.fallback(v.number(), 10 * 1024 * 1024),
+  sslVerify: v.fallback(v.boolean(), true),
   auth: v.optional(AuthSchema),
   image: v.optional(ImageSchema),
   onProgress: v.optional(ProgressCallbackSchema),
@@ -86,6 +81,6 @@ export enum ContentTypes {
 export type Auth = v.InferInput<typeof AuthSchema>;
 export type Image = v.InferInput<typeof ImageSchema>;
 export type ProgressCallback = v.InferInput<typeof ProgressCallbackSchema>;
-export type ApplicationConfiguration = v.InferInput<
-  typeof ApplicationConfigurationSchema
+export type ApplicationConfiguration = v.InferOutput<
+  typeof DockerTarPusherOptionsSchema
 >;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    testTimeout: 30_000,
+    testTimeout: 60_000,
     env: config({
       path: ".env.test",
     }).parsed,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ const dotenvFile = process.env.CI ? ".env.ci" : ".env.test";
 
 export default defineConfig({
   test: {
+    testTimeout: 10000,
     env: config({
       path: dotenvFile,
     }).parsed,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    testTimeout: 10000,
+    testTimeout: 30_000,
     env: config({
       path: ".env.test",
     }).parsed,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,13 +1,11 @@
 import { config } from "dotenv";
 import { defineConfig } from "vitest/config";
 
-const dotenvFile = process.env.CI ? ".env.ci" : ".env.test";
-
 export default defineConfig({
   test: {
     testTimeout: 10000,
     env: config({
-      path: dotenvFile,
+      path: ".env.test",
     }).parsed,
     globals: true,
     coverage: {


### PR DESCRIPTION
…ling

- ManifestSchema validates PascalCase Docker keys, outputs camelCase via v.transform; Manifest type uses InferOutput
- DockerTarPusherOptionsSchema uses v.fallback for defaults, eliminating the redundant ApplicationConfigurationSchema; constructor now validates via v.parse
- Replace stateful ManifestBuilder class with a pure buildManifest function; fix layer accumulation bug across multiple RepoTags
- Use isAxiosError consistently in DockerRegistryService catch blocks